### PR TITLE
Fixed ordered list item prefix in optinal setup section in App Readme

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -23,7 +23,7 @@
 
 ### 🔩 Optional Setup
 
-4. **Install tmux and tmuxinator locally:**
+1. **Install tmux and tmuxinator locally:**
    To run 'bun dev', ensure you have tmux and tmuxinator installed locally.
    - **Tmux:** Install Tmux using your package manager
      (e.g., `apt install tmux` for a Debian/Ubuntu based distro).


### PR DESCRIPTION
## What type of PR is this? (Check all applicable)

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [x] 📚 Documentation
- [ ] 💻 Blog post
- [ ] 🎨 Styles
- [ ] 🛠️ Refactoring
- [ ] 🕵️‍♀️ Code Review
- [ ] 🚑 Hotfix
- [ ] 🧪 Test
- [ ] 🌐 Localization/Internationalization
- [ ] ⚙️  Configuration and Environment
- [ ] 🚫 Deprecation or Removal
- [ ] 📦 Release
- [ ] ⏪ Revert

## Description

**Please describe the changes in this pull request:**
Corrected numbering in the optional setup section of the App Readme. The list started with 4. instead of 1. It needed to start anew as a separate list.

## Related Issues

Please link related issues by removing lines that are not applicable.


## Checklist

**Before submitting this pull request, please make sure you have done the following:**

### Code Quality

- [ ] Reviewed your code for any potential issues.
- [ ] Checked for coding style and formatting.

### Updated documentation?

- [ ] ✅ Yes
- [x] 🙅 No, because there is nothing to update
- [ ] 🙋‍♂️ No, I need help

### Added tests for your changes?

- [ ] ✅ Yes
- [x] 🙅 No, because they are not needed
- [ ] 🙋‍♂️ No, I need help

### UI Changes

- [ ] Added screenshots or recordings to demonstrate UI-related changes (if applicable).

## Additional Information

Replace this text with any additional information.

