### PR TITLE
Add redirect to the user browser prefered locale

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
     locales: Object.keys(languages),
     routing: {
       prefixDefaultLocale: true,
+      redirectToDefaultLocale: false,
     },
   },
 })

--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import {  fallbackLang , ui } from '@services/i18n/ui'
+
+const preferedLanguage = Astro.preferredLocale
+
+if(null != preferedLanguage && preferedLanguage in ui) return Astro.redirect(preferedLanguage)
+
+return Astro.redirect(fallbackLang)
+---


### PR DESCRIPTION
## What type of PR is this? (Check all applicable)

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation
- [ ] 💻 Blog post
- [ ] 🎨 Styles
- [ ] 🛠️ Refactoring
- [ ] 🕵️‍♀️ Code Review
- [ ] 🚑 Hotfix
- [ ] 🧪 Test
- [x] 🌐 Localization/Internationalization
- [ ] ⚙️  Configuration and Environment
- [ ] 🚫 Deprecation or Removal
- [ ] 📦 Release
- [ ] ⏪ Revert

## Description

**Please describe the changes in this pull request:**

Add a redirect to the user prefered language when visiting '/'. 
To achieve this, the default locale redirect has been disabled in astro config.

## Related Issues

Please link related issues by removing lines that are not applicable.

- Addresses #155 

## Checklist

**Before submitting this pull request, please make sure you have done the following:**

### Code Quality

- [x] Reviewed your code for any potential issues.
- [x] Checked for coding style and formatting.

### Updated documentation?

- [ ] ✅ Yes
- [x] 🙅 No, because there is nothing to update
- [ ] 🙋‍♂️ No, I need help

### Added tests for your changes?

- [ ] ✅ Yes
- [x] 🙅 No, because they are not needed
- [ ] 🙋‍♂️ No, I need help

### UI Changes

- [ ] Added screenshots or recordings to demonstrate UI-related changes (if applicable).

## Additional Information

Replace this text with any additional information.

